### PR TITLE
Better path segment escaping

### DIFF
--- a/Network/HTTP/Types.hs
+++ b/Network/HTTP/Types.hs
@@ -405,7 +405,7 @@ ord8 = fromIntegral . ord
 
 unreservedQS, unreservedPI :: [Word8]
 unreservedQS = map ord8 "-_.~"
-unreservedPI = map ord8 ":@&=+$,"
+unreservedPI = map ord8 "-_.~:@&=+$,"
 
 -- | Percent-encoding for URLs.
 urlEncodeBuilder' :: [Word8] -> B.ByteString -> Blaze.Builder

--- a/runtests.hs
+++ b/runtests.hs
@@ -7,17 +7,21 @@ import           Debug.Trace
 import           Network.HTTP.Types
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
+import           Test.Hspec.HUnit
 import           Test.QuickCheck          (Arbitrary (..))
+import           Test.HUnit
 import qualified Blaze.ByteString.Builder as Blaze
 import qualified Data.ByteString          as S
 import qualified Data.ByteString.Char8    as S8
 import qualified Data.Text                as T
 
-main :: IO ()
+--main :: IO ()
 main = hspec $ descriptions
     [ describe "encode/decode path"
         [ it "is identity to encode and then decode"
             $ property propEncodeDecodePath
+        , it "does not escape period and dash" $
+            Blaze.toByteString (encodePath ["foo-bar.baz"] []) @?= "/foo-bar.baz"
         ]
     , describe "encode/decode query"
         [ it "is identity to encode and then decode"


### PR DESCRIPTION
I was missing some characters for unreservedPI. In particular, dashes and periods are currently being encoded when they needn't be.
