### PR TITLE
Add more complete list of available statuses

### DIFF
--- a/Network/HTTP/Types.hs
+++ b/Network/HTTP/Types.hs
@@ -58,6 +58,7 @@ module Network.HTTP.Types
 , status415, statusUnsupportedMediaType
 , status416, statusRequestedRangeNotSatisfiable
 , status417, statusExpectationFailed
+, status418, statusImATeapot
 , status500, statusServerError
 , status501, statusNotImplemented
 , status502, statusBadGateway
@@ -383,6 +384,11 @@ statusRequestedRangeNotSatisfiable = status416
 status417, statusExpectationFailed :: Status
 status417 = Status 417 "Expectation Failed"
 statusExpectationFailed = status417
+
+-- | I'm a teapot
+status418, statusImATeapot :: Status
+status418 = Status 418 "I'm a teapot"
+statusImATeapot = status418
 
 -- | Internal Server Error
 status500, statusServerError :: Status


### PR DESCRIPTION
This includes both 1xx statuses as well as missing 2xx, 3xx, 4xx and 5xx statuses. The only exception is 306 which is now unused (used in a previous specification version, but since removed).
