### PR TITLE
Relax constraint on array dependancy

### DIFF
--- a/http-types.cabal
+++ b/http-types.cabal
@@ -59,7 +59,7 @@ Library
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
                        bytestring >=0.9.1.5 && <0.10,
-                       array >=0.2 && <0.4,
+                       array >=0.2 && <0.5,
                        case-insensitive >=0.2 && <0.5,
                        blaze-builder >= 0.2.1.4 && < 0.4,
                        text >= 0.11.0.2 && < 0.12


### PR DESCRIPTION
GHC 7.4 ships with array-0.4.0.0
