### PR TITLE
Increment upper bound on bytestring for GHC 7.6

### DIFF
--- a/http-types.cabal
+++ b/http-types.cabal
@@ -60,7 +60,7 @@ Library
   
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
-                       bytestring >=0.9.1.5 && <0.10,
+                       bytestring >=0.9.1.5 && <0.11,
                        array >=0.2 && <0.5,
                        case-insensitive >=0.2 && <0.5,
                        blaze-builder >= 0.2.1.4 && < 0.4,


### PR DESCRIPTION
Incremented upper bound for bytestring dependency in .cabal file.
