### PR TITLE
Replace Blaze builder with bytestring-builder

### DIFF
--- a/Network/HTTP/Types/URI.hs
+++ b/Network/HTTP/Types/URI.hs
@@ -42,8 +42,9 @@ import           Data.Text                      (Text)
 import           Data.Text.Encoding             (encodeUtf8, decodeUtf8With)
 import           Data.Text.Encoding.Error       (lenientDecode)
 import           Data.Word
-import qualified Blaze.ByteString.Builder       as Blaze
 import qualified Data.ByteString                as B
+import qualified Data.ByteString.Lazy           as L
+import qualified Data.ByteString.Lazy.Builder   as B
 import           Data.ByteString.Char8          () {-IsString-}
 
 -- | Query item
@@ -62,10 +63,10 @@ type QueryText = [(Text, Maybe Text)]
 queryTextToQuery :: QueryText -> Query
 queryTextToQuery = map $ encodeUtf8 *** fmap encodeUtf8
 
--- | Convert 'QueryText' to a 'Blaze.Builder'.
+-- | Convert 'QueryText' to a 'B.Builder'.
 renderQueryText :: Bool -- ^ prepend a question mark?
                 -> QueryText
-                -> Blaze.Builder
+                -> B.Builder
 renderQueryText b = renderQueryBuilder b . queryTextToQuery
 
 -- | Convert 'Query' to 'QueryText' (leniently decoding the UTF-8).
@@ -92,16 +93,16 @@ simpleQueryToQuery = map (\(a, b) -> (a, Just b))
 -- | Convert 'Query' to a 'Builder'.
 renderQueryBuilder :: Bool -- ^ prepend a question mark?
                    -> Query
-                   -> Blaze.Builder
+                   -> B.Builder
 renderQueryBuilder _ [] = mempty
 -- FIXME replace mconcat + map with foldr
 renderQueryBuilder qmark' (p:ps) = mconcat
     $ go (if qmark' then qmark else mempty) p
     : map (go amp) ps
   where
-    qmark = Blaze.copyByteString "?"
-    amp = Blaze.copyByteString "&"
-    equal = Blaze.copyByteString "="
+    qmark = B.byteString "?"
+    amp = B.byteString "&"
+    equal = B.byteString "="
     go sep (k, mv) = mconcat [
                       sep
                      , urlEncodeBuilder True k
@@ -113,7 +114,7 @@ renderQueryBuilder qmark' (p:ps) = mconcat
 -- | Convert 'Query' to 'ByteString'.
 renderQuery :: Bool -- ^ prepend question mark?
             -> Query -> B.ByteString
-renderQuery qm = Blaze.toByteString . renderQueryBuilder qm
+renderQuery qm = L.toStrict . B.toLazyByteString . renderQueryBuilder qm
 
 -- | Convert 'SimpleQuery' to 'ByteString'.
 renderSimpleQuery :: Bool -- ^ prepend question mark?
@@ -171,10 +172,10 @@ unreservedQS = map ord8 "-_.~"
 unreservedPI = map ord8 "-_.~:@&=+$,"
 
 -- | Percent-encoding for URLs.
-urlEncodeBuilder' :: [Word8] -> B.ByteString -> Blaze.Builder
+urlEncodeBuilder' :: [Word8] -> B.ByteString -> B.Builder
 urlEncodeBuilder' extraUnreserved = mconcat . map encodeChar . B.unpack
     where
-      encodeChar ch | unreserved ch = Blaze.fromWord8 ch
+      encodeChar ch | unreserved ch = B.word8 ch
                     | otherwise     = h2 ch
       
       unreserved ch | ch >= 65 && ch <= 90  = True -- A-Z
@@ -182,21 +183,21 @@ urlEncodeBuilder' extraUnreserved = mconcat . map encodeChar . B.unpack
                     | ch >= 48 && ch <= 57  = True -- 0-9
       unreserved c = c `elem` extraUnreserved
       
-      h2 v = let (a, b) = v `divMod` 16 in Blaze.fromWord8s [37, h a, h b] -- percent (%)
+      h2 v = let (a, b) = v `divMod` 16 in (mconcat $ map B.word8 [37, h a, h b]) -- percent (%)
       h i | i < 10    = 48 + i -- zero (0)
           | otherwise = 65 + i - 10 -- 65: A
 
--- | Percent-encoding for URLs (using 'Blaze.Builder').
+-- | Percent-encoding for URLs (using 'B.Builder').
 urlEncodeBuilder
     :: Bool -- ^ Whether input is in query string. True: Query string, False: Path element
     -> B.ByteString
-    -> Blaze.Builder
+    -> B.Builder
 urlEncodeBuilder True  = urlEncodeBuilder' unreservedQS
 urlEncodeBuilder False = urlEncodeBuilder' unreservedPI
 
 -- | Percent-encoding for URLs.
 urlEncode :: Bool -> B.ByteString -> B.ByteString
-urlEncode q = Blaze.toByteString . urlEncodeBuilder q
+urlEncode q = L.toStrict . B.toLazyByteString . urlEncodeBuilder q
 
 -- | Percent-decoding.
 urlDecode :: Bool -- ^ Whether to decode '+' to ' '
@@ -249,18 +250,18 @@ urlDecode replacePlus z = fst $ B.unfoldrN (B.length z) go z
 -- Huge thanks to Jeremy Shaw who created the original implementation of this
 -- function in web-routes and did such thorough research to determine all
 -- correct escaping procedures.
-encodePathSegments :: [Text] -> Blaze.Builder
+encodePathSegments :: [Text] -> B.Builder
 encodePathSegments [] = mempty
 encodePathSegments (x:xs) =
-    Blaze.copyByteString "/"
+    B.byteString "/"
     `mappend` encodePathSegment x
     `mappend` encodePathSegments xs
 
 -- | Like encodePathSegments, but without the initial slash.
-encodePathSegmentsRelative :: [Text] -> Blaze.Builder
-encodePathSegmentsRelative xs = mconcat $ intersperse (Blaze.copyByteString "/") (map encodePathSegment xs)
+encodePathSegmentsRelative :: [Text] -> B.Builder
+encodePathSegmentsRelative xs = mconcat $ intersperse (B.byteString "/") (map encodePathSegment xs)
 
-encodePathSegment :: Text -> Blaze.Builder
+encodePathSegment :: Text -> B.Builder
 encodePathSegment = urlEncodeBuilder False . encodeUtf8
 
 -- | Parse a list of path segments from a valid URL fragment.
@@ -285,7 +286,7 @@ decodePathSegment :: B.ByteString -> Text
 decodePathSegment = decodeUtf8With lenientDecode . urlDecode False
 
 -- | Encode a whole path (path segments + query).
-encodePath :: [Text] -> Query -> Blaze.Builder
+encodePath :: [Text] -> Query -> B.Builder
 encodePath x [] = encodePathSegments x
 encodePath x y = encodePathSegments x `mappend` renderQueryBuilder True y
 

--- a/http-types.cabal
+++ b/http-types.cabal
@@ -69,10 +69,9 @@ Library
   
   -- Packages needed in order to build this package.
   Build-depends:       base >= 4 && < 5,
-                       bytestring >=0.9.1.5 && <0.11,
+                       bytestring >=0.10 && <0.11,
                        array >=0.2 && <0.6,
                        case-insensitive >=0.2 && <1.2,
-                       blaze-builder >= 0.2.1.4 && < 0.4,
                        text >= 0.11.0.2 && < 0.12
   
   -- Modules not exported by this package.

--- a/test/runtests.hs
+++ b/test/runtests.hs
@@ -5,10 +5,11 @@ import           Debug.Trace
 import           Network.HTTP.Types
 import           Test.Hspec
 import           Test.QuickCheck
-import qualified Blaze.ByteString.Builder as Blaze
-import qualified Data.ByteString          as S
-import qualified Data.ByteString.Char8    as S8
-import qualified Data.Text                as T
+import qualified Data.ByteString.Lazy.Builder as B
+import qualified Data.ByteString              as S
+import qualified Data.ByteString.Char8        as S8
+import qualified Data.ByteString.Lazy         as L
+import qualified Data.Text                    as T
 
 main :: IO ()
 main = hspec $ do
@@ -16,7 +17,7 @@ main = hspec $ do
       it "is identity to encode and then decode" $
         property propEncodeDecodePath
       it "does not escape period and dash" $
-        Blaze.toByteString (encodePath ["foo-bar.baz"] []) `shouldBe` "/foo-bar.baz"
+        (L.toStrict . B.toLazyByteString) (encodePath ["foo-bar.baz"] []) `shouldBe` "/foo-bar.baz"
 
     describe "encode/decode query" $ do
       it "is identity to encode and then decode" $
@@ -46,7 +47,7 @@ main = hspec $ do
 
 propEncodeDecodePath :: ([Text], Query) -> Bool
 propEncodeDecodePath (p', q') =
-    let x = Blaze.toByteString $ encodePath a b
+    let x = L.toStrict . B.toLazyByteString $ encodePath a b
         y = decodePath x
         z = y == (a, b)
      in if z then z else traceShow (a, b, x, y) z
@@ -74,7 +75,7 @@ propQueryQuestionMark (useQuestionMark, query) = actual == expected
 
 propEncodeDecodePathSegments :: [Text] -> Bool
 propEncodeDecodePathSegments p' =
-    p == decodePathSegments (Blaze.toByteString $ encodePathSegments p)
+    p == decodePathSegments (L.toStrict . B.toLazyByteString $ encodePathSegments p)
   where
     p = if p' == [""] then [] else p'
 


### PR DESCRIPTION
Bytestring's builder is meant to subsume blaze-builder anyway. More
importantly, as of 0.10.4, Bytestring's builder module is marked
Trustworthy, making *all* of http-types Safe when that version is used.

I've only changed the version dependecy to the earlist one where `Data.ByteString.Lazy.Builder` is available to make the transition as easy as possible, even thought this module is going to be deprecated in favor of `Data.ByteString.Builder` and is not marked trustworthy until 0.10.4.