### PR TITLE
Added urlEncode parameter docs

### DIFF
--- a/Network/HTTP/Types/URI.hs
+++ b/Network/HTTP/Types/URI.hs
@@ -196,7 +196,9 @@ urlEncodeBuilder True  = urlEncodeBuilder' unreservedQS
 urlEncodeBuilder False = urlEncodeBuilder' unreservedPI
 
 -- | Percent-encoding for URLs.
-urlEncode :: Bool -> B.ByteString -> B.ByteString
+urlEncode :: Bool -- ^ Whether to decode '+' to ' '
+          -> B.ByteString -- ^ The ByteString to encode as URL
+          -> B.ByteString -- ^ The encoded URL
 urlEncode q = Blaze.toByteString . urlEncodeBuilder q
 
 -- | Percent-decoding.


### PR DESCRIPTION
Every time I use `urlEncode` I have to look up what the `Bool` parameter means. Although it is documented in `urlEncodeBuilder`, I believe it should also be added to the `urlEncode` docs.
