### PR TITLE
Compiling http-types with blaze-builder-0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
+.cabal-sandbox
+cabal.sandbox.config
 dist/*
+

--- a/http-types.cabal
+++ b/http-types.cabal
@@ -35,7 +35,7 @@ Library
                        bytestring >=0.9.1.5 && <0.11,
                        array >=0.2 && <0.6,
                        case-insensitive >=0.2 && <1.3,
-                       blaze-builder >= 0.2.1.4 && < 0.4,
+                       blaze-builder >= 0.2.1.4 && < 0.5,
                        text >= 0.11.0.2
 
 Test-suite spec


### PR DESCRIPTION
http-types actually works with blaze-builder-0.4. I've updated cabal file.

    $ cabal sandbox init
    Writing a default package environment file to
    /tmp/http-types/cabal.sandbox.config
    Creating a new sandbox at /tmp/http-types/.cabal-sandbox
    $ cabal install . blaze-builder-0.4.0.0
    Resolving dependencies...
    Notice: installing into a sandbox located at /tmp/http-types/.cabal-sandbox
    Configuring text-1.2.0.4...
    Building text-1.2.0.4...
    Installed text-1.2.0.4
    Downloading blaze-builder-0.4.0.0...
    Configuring hashable-1.2.3.1...
    Building hashable-1.2.3.1...
    Configuring blaze-builder-0.4.0.0...
    Building blaze-builder-0.4.0.0...
    Installed hashable-1.2.3.1
    Configuring case-insensitive-1.2.0.4...
    Building case-insensitive-1.2.0.4...
    Installed blaze-builder-0.4.0.0
    Installed case-insensitive-1.2.0.4
    Configuring http-types-0.8.5...
    Building http-types-0.8.5...
    Installed http-types-0.8.5

Fixing https://github.com/aristidb/http-types/issues/49