### PR TITLE
Added 'hRefresh' for (non-standed) HTTP Refresh header

### DIFF
--- a/Network/HTTP/Types/Header.hs
+++ b/Network/HTTP/Types/Header.hs
@@ -24,6 +24,7 @@ module Network.HTTP.Types.Header
 , hLocation
 , hRange
 , hReferer
+, hRefresh
 , hServer
 , hUserAgent
   -- ** Byte ranges
@@ -59,7 +60,7 @@ type RequestHeaders = [Header]
 type ResponseHeaders = [Header]
 
 -- | HTTP Header names
-hAccept, hAcceptLanguage, hAuthorization, hCacheControl, hConnection, hContentEncoding, hContentLength, hContentMD5, hContentType, hCookie, hDate, hIfModifiedSince, hIfRange, hLastModified, hLocation, hRange, hReferer, hServer, hUserAgent :: HeaderName
+hAccept, hAcceptLanguage, hAuthorization, hCacheControl, hConnection, hContentEncoding, hContentLength, hContentMD5, hContentType, hCookie, hDate, hIfModifiedSince, hIfRange, hLastModified, hLocation, hRange, hReferer, hRefresh, hServer, hUserAgent :: HeaderName
 hAccept          = "Accept"
 hAcceptLanguage  = "Accept-Language"
 hAuthorization   = "Authorization"
@@ -77,6 +78,7 @@ hLastModified    = "Last-Modified"
 hLocation        = "Location"
 hRange           = "Range"
 hReferer         = "Referer"
+hRefresh         = "Refresh"
 hServer          = "Server"
 hUserAgent       = "User-Agent"
 


### PR DESCRIPTION
HTTP 'Refresh' headers are not standard, but commonly supported by HTTP
clients (e.g. browsers or web crawlers) ever since Netscape introduced
the feature.

Websites sometimes use the HTTP Refresh header instead of the <meta
http-equiv="Refresh" ..> tag (Wikipedia suggests it's because the HTTP
header makes life easier for CGI programs since the status code doesn't
need to be changed).