### PR TITLE
Add headers from RFC2616 section 19

### DIFF
--- a/Network/HTTP/Types/Header.hs
+++ b/Network/HTTP/Types/Header.hs
@@ -55,6 +55,8 @@ module Network.HTTP.Types.Header
 , hVia
 , hWWWAuthenticate
 , hWarning
+, hContentDisposition
+, hMIMEVersion
   -- ** Byte ranges
 , ByteRange(..)
 , renderByteRangeBuilder
@@ -142,6 +144,12 @@ hVary               = "Vary"
 hVia                = "Via"
 hWWWAuthenticate    = "WWW-Authenticate"
 hWarning            = "Warning"
+
+-- | HTTP Header names
+-- According to http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html
+hContentDisposition, hMIMEVersion :: HeaderName
+hContentDisposition = "Content-Disposition"
+hMIMEVersion        = "MIME-Version"
 
 -- | RFC 2616 Byte range (individual).
 --


### PR DESCRIPTION
There are two headers mentioned in RFC2616, section 19.

`Content-Disposition` is said to be experimental (in a sense -- it is often implemented, but different implementations might be inconsistent). Major browser use it to choose whether to show contents inline or save it as a file with specified name.

`MIME-Version` here is just for completeness (there are only two headers in the section, so I think it won't hurt to add it too). AFAIK it is pretty stable, since it goes only with value `1.0`. 