### PR TITLE
Add parseQueryReplacePlus function

### DIFF
--- a/test/Network/HTTP/Types/URISpec.hs
+++ b/test/Network/HTTP/Types/URISpec.hs
@@ -91,3 +91,14 @@ spec = do
         context "when path is empty" $ do
           it "returns /" $ do
             extractPath "https://example.com" `shouldBe` "/"
+
+  describe "parseQuery" $ do
+    it "returns value with '+' replaced to ' '" $ do
+      parseQuery "?a=b+c+d" `shouldBe` [("a", Just "b c d")]
+
+  describe "parseQueryReplacePlus" $ do
+    it "returns value with '+' replaced to ' '" $ do
+      parseQueryReplacePlus True "?a=b+c+d" `shouldBe` [("a", Just "b c d")]
+
+    it "returns value with '+' preserved" $ do
+      parseQueryReplacePlus False "?a=b+c+d" `shouldBe` [("a", Just "b+c+d")]


### PR DESCRIPTION
Currently the `parseQuery` function uses `urlDecode True` which converts `+` to space, my understanding is that this is desirable when having a `x-www-form-urlencoded` payload but not on every case, in particular for [PostgREST](https://github.com/begriffs/postgrest/issues/1078#issuecomment-374643959) we would like to be able to have an expression in the querystring that makes `+` meaningful.

This adds a new function(to preserve backward compatibility) that allows to set the `urlDecode` mode.

