### PR TITLE
Remove no longer necessary and valid doctest option

### DIFF
--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -4,9 +4,6 @@ import Test.DocTest
 
 main :: IO ()
 main = doctest [
-    "-idist/build/autogen/"
-  , "-optP-include"
-  , "-optPdist/build/autogen/cabal_macros.h"
-  , "-XOverloadedStrings"
+    "-XOverloadedStrings"
   , "Network/HTTP/Types.hs"
   ]


### PR DESCRIPTION
It looks like this was needed previously for builds with `cabal-install` but is not required anymore. It was failing with Stack and it appears that with those "bad" options removed it still works with old Cabal builds and also works with new-build and Stack.